### PR TITLE
Exit with help if no command line arguments.

### DIFF
--- a/nanomonsv/__init__.py
+++ b/nanomonsv/__init__.py
@@ -1,10 +1,14 @@
 #! /usr/bin/env python
 
+import sys
 from .arg_parser import create_parser
 
 def main():
 
     parser = create_parser()
     args = parser.parse_args()
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
     args.func(args)
 


### PR DESCRIPTION
Hi @friend1ws and nanomonsv contributors.

I recently had the opportunity to run nanomonsv on long-read sequence data and found something I could contribute to its usability.

### Actual behavior

If you run the nanomonsv command with no arguments, you will receive the following error:

```
nanomonsv
```

```console
Traceback (most recent call last):
  File "/home/kojix2/miniconda3/envs/nanomonsv_dev/bin/nanomonsv", line 33, in <module>
    sys.exit(load_entry_point('nanomonsv==0.5.1b0', 'console_scripts', 'nanomonsv')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kojix2/miniconda3/envs/nanomonsv_dev/lib/python3.11/site-packages/nanomonsv-0.5.1b0-py3.11.egg/nanomonsv/__init__.py", line 9, in main
AttributeError: 'Namespace' object has no attribute 'func'
```

### Expected behavior

Generally, when a command is executed with no arguments, the expected behavior is to print "help" to the standard error output and exit abnormally. For example, minimap2 works that way.

```sh
minimap2        # Output help to STDERR
echo $?         # 1
minimap2 --help # Output help to STDOUT
echo $?         # 0
```

I am not very familiar with Python practices, so if there are any corrections that need to be made, please feel free to overwrite this commit with additional commits.

Thank you.